### PR TITLE
Add 'grafana' as a type for HAProxy

### DIFF
--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -137,6 +137,11 @@ listen {{ listen_name }}
   stats  uri /
   stats  http-request auth realm admin_page unless AuthOkay_ReadOnly
   stats  admin if AuthOkay_Admin
+  {%- elif listen.get('type', None) == 'grafana' %}
+  balance  source
+  mode  http
+  option  httplog
+  option  dontlog-normal
   {%- else %}
   {# no type specified #}
   mode {{ listen.mode|default('tcp') }}


### PR DESCRIPTION
This patch adds the type Grafana that uses the mode 'source' to keep
the same HAProxy backend for a given source. Otherwise authentication
will be asked for each requests.