### PR TITLE
Fix annotations in Grafana dashboard

### DIFF
--- a/haproxy/files/grafana_influxdb.json
+++ b/haproxy/files/grafana_influxdb.json
@@ -9,7 +9,7 @@
         "iconSize": 13,
         "lineColor": "rgba(255, 96, 96, 0.592157)",
         "name": "Status",
-        "query": "select title,tags,text from annotations where $timeFilter and cluster = 'haproxy'",
+        "query": "select title,tags,text from annotations where $timeFilter and cluster = 'haproxy-openstack'",
         "showLine": true,
         "tagsColumn": "tags",
         "textColumn": "text",
@@ -2844,5 +2844,5 @@
   },
   "timezone": "browser",
   "title": "HAProxy",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
The haproxy cluster name is "haproxy-openstack".