### PR TITLE
HTTP check via HAProxy should not fail on 404

### DIFF
--- a/haproxy/meta/sensu.yml
+++ b/haproxy/meta/sensu.yml
@@ -29,7 +29,7 @@ check:
 {%- endif %}
 {%- if listen.type|default(None) in ['general-service', 'openstack-service', 'http', 'contrail-api', 'admin'] or listen.mode|default('tcp') == 'http' %}
   remote_haproxy_proxy_http_{{ listen_name }}_{{ network.fqdn }}:
-    command: "PATH=$PATH:/usr/lib64/nagios/plugins:/usr/lib/nagios/plugins check_http -H {{ address }} -p {{ listen.binds.0.port }} -w 5 -c 10"
+    command: "PATH=$PATH:/usr/lib64/nagios/plugins:/usr/lib/nagios/plugins check_http -H {{ address }} -p {{ listen.binds.0.port }} -w 5 -c 10 -e HTTP/1. -N"
     interval: 60
     occurrences: 1
     subscribers:


### PR DESCRIPTION
Because of nature of frontend checks, it should check only that frontend
is passed the request, not nature of request. So check_http will be
called with -E -N.

This is useful for checking sensu, which is returning 404 on /.